### PR TITLE
Correctly check for missing castling rights or en passant information in Position::is_valid_fen

### DIFF
--- a/Chess/position.cpp
+++ b/Chess/position.cpp
@@ -2354,23 +2354,25 @@ bool Position::is_valid_fen(const std::string &fen) {
    std::istringstream iss(fen);
    std::string board, side, castleRights, ep;
 
-   if (!iss) return false;
-
    iss >> board;
 
-   if (!iss) return false;
+   if (board.empty()) return false;
 
    iss >> side;
 
-   if (!iss) {
-      castleRights = "-";
-      ep = "-";
+   if (side.empty()) return false;
+
+   iss >> castleRights;
+
+   if (castleRights.empty()) {
+     castleRights = "-";
+     ep = "-";
    } else {
-      iss >> castleRights;
-      if (iss)
-         iss >> ep;
-      else
-         ep = "-";
+     iss >> ep;
+
+     if (ep.empty()) {
+       ep = "-";
+     }
    }
 
    // Let's check that all components of the supposed FEN are OK.

--- a/StockfishTests/PositionTest.mm
+++ b/StockfishTests/PositionTest.mm
@@ -47,4 +47,22 @@ using namespace Chess;
     XCTAssertTrue(p->is_ok(), @"You probably didn't do chess init");
 }
 
+- (void)testValidFen
+{
+    NSString *fen = @"rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3";
+    XCTAssertTrue(Position::is_valid_fen([fen UTF8String]));
+}
+
+- (void)testValidFenNoEp
+{
+    NSString *fen = @"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq";
+    XCTAssertTrue(Position::is_valid_fen([fen UTF8String]));
+}
+
+- (void)testValidFenNoCastlingRights
+{
+    NSString *fen = @"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w";
+    XCTAssertTrue(Position::is_valid_fen([fen UTF8String]));
+}
+
 @end


### PR DESCRIPTION
Incorrect checking of missing castling rights or en passant information was leading to Position::is_valid_fen declaring valid FEN strings as invalid.

For example, the following string would be declared as invalid:

`rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq`

This fix correctly checks for this missing information, and adds some tests including two which should fail without this fix. I wasn't able to run the tests because I ran into some problems with Xcode.

By the way, love the app!
