### PR TITLE
Fix freeze at startup

### DIFF
--- a/Stockfish/SFMUCIEngine.m
+++ b/Stockfish/SFMUCIEngine.m
@@ -251,7 +251,7 @@ static volatile int32_t instancesAnalyzing = 0;
     NSTask *task = [[NSTask alloc] init];
     [task setLaunchPath:@"/usr/sbin/sysctl"];
     [task setStandardOutput:outputPipe];
-    [task setArguments:@[@"-n", @"machdep.cpu"]];
+    [task setArguments:@[@"-n", @"machdep.cpu.features", @"machdep.cpu.leaf7_features"]];
     [task launch];
     [task waitUntilExit];
     NSData *data = [[outputPipe fileHandleForReading] availableData];


### PR DESCRIPTION
On my iMac (late 2015), waitUntilExit never returns, causing the application to hang forever.
Restricting the output of sysctl to the relevant fields seems to fix the issue.