### PR TITLE
Update movegen.cpp

### DIFF
--- a/Chess/movegen.cpp
+++ b/Chess/movegen.cpp
@@ -913,7 +913,6 @@ namespace {
     if(pos.ep_square() != SQ_NONE) {
       assert(square_rank(pos.ep_square()) == RANK_6);
       b1 = pawns & pos.black_pawn_attacks(pos.ep_square());
-      assert(b1 != EmptyBoardBB);
       while(b1) {
         sq = pop_1st_bit(&b1);
         mlist[n++].move = make_ep_move(sq, pos.ep_square());
@@ -976,7 +975,6 @@ namespace {
     if(pos.ep_square() != SQ_NONE) {
       assert(square_rank(pos.ep_square()) == RANK_3);
       b1 = pawns & pos.white_pawn_attacks(pos.ep_square());
-      assert(b1 != EmptyBoardBB);
       while(b1) {
         sq = pop_1st_bit(&b1);
         mlist[n++].move = make_ep_move(sq, pos.ep_square());


### PR DESCRIPTION
These asserts go off on valid FENs like these:
rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1
rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w KQkq c6 0 2