### PR TITLE
Fix promotion and annotations

### DIFF
--- a/Chess/san.cpp
+++ b/Chess/san.cpp
@@ -443,7 +443,7 @@ namespace {
   const std::string score_string(Value v) {
     std::stringstream s;
 
-    if(abs(v) >= VALUE_MATE - 200) {
+    if(v >= VALUE_MATE - 200) {
       if(v < 0)
         s << "-#" << (VALUE_MATE + v) / 2;
       else

--- a/Chess/value.cpp
+++ b/Chess/value.cpp
@@ -83,7 +83,7 @@ Value value_from_centipawns(int cp) {
 const std::string value_to_string(Value v) {
   std::stringstream s;
 
-  if(abs(v) < VALUE_MATE - 200)
+  if(v < VALUE_MATE - 200)
     s << "cp " << value_to_centipawns(v);
   else {
     s << "mate ";

--- a/Stockfish/SFMPosition.mm
+++ b/Stockfish/SFMPosition.mm
@@ -28,6 +28,25 @@ using namespace Chess;
 
 @end
 
+NSString* const moveRegex =
+@"("
+"[BRQNK][a-h][1-8]|" // Piece moves (Ba8)
+"[BRQNK]x[a-h][1-8]|" // Captures (Qxe6)
+"[BRQN][a-h][a-h][1-8]|" // Ambiguous column moves (Rae1)
+"[BRQN][a-h]x[a-h][1-8]|" // Ambiguous column captures (Raxd1)
+"[BRQN][1-8][a-h][1-8]|" // Ambiguous row moves (R1e2)
+"[BRQN][1-8]x[a-h][1-8]|" // Ambiguous row captures (R3xa4)
+"[a-h][2-7]|" // Pawn moves (e4)
+"[a-h]x[a-h][2-7]|" // Pawn captures (exd5)
+"[a-h][18]=[BRQN]|" // Promotions (c8=Q)
+"[a-h]x[a-h][18]=[BRQN]|" // Capture and promotion (bxa8=Q)
+"O-O|" // Short castle
+"O-O-O|" // Long castle
+")"
+"[\\+#]?" // Check / mate
+"([!?]{0,2})" // Move annotation (!?, ??, ?)
+;
+
 @implementation SFMPosition
 @synthesize position = _position;
 
@@ -156,8 +175,8 @@ using namespace Chess;
     NSArray *tokens = [san componentsSeparatedByCharactersInSet:cSet];
     for(NSString *tok in tokens){
         if([tok length] > 0 && [SFMParser isLetter:[tok characterAtIndex:0]]){
-            NSRegularExpression *moveRegex = [NSRegularExpression regularExpressionWithPattern:@"([a-zA-Z\\-1-8]+)[+#]{0,1}([!?]{0,2})" options:0 error:nil];
-            NSTextCheckingResult *match = [moveRegex firstMatchInString:tok options:0 range:NSMakeRange(0, tok.length)];
+            NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:moveRegex options:0 error:nil];
+            NSTextCheckingResult *match = [regex firstMatchInString:tok options:0 range:NSMakeRange(0, tok.length)];
             NSString *moveString = [tok substringWithRange:[match rangeAtIndex:1]];
             NSString *moveAnnotation = [tok substringWithRange:[match rangeAtIndex:2]];
             Move m = move_from_san(*self.position, [moveString UTF8String]);
@@ -282,33 +301,46 @@ using namespace Chess;
  @param string The move text
  @param nodes The nodes for which the move text was generated
  */
-- (void)setMoveAttributes:(NSMutableAttributedString*)string nodes:(NSArray *)nodes
+- (void)setMoveAttributes:(NSMutableAttributedString*)attributedString nodes:(NSArray *)nodes
 {
     NSError *error = nil;
-    NSRegularExpression *moveNumberRegex = [NSRegularExpression regularExpressionWithPattern:@"\\d+\\.+" options:0 error:&error];
-    
-    NSString *str = [string string];
-    NSArray *matches = [moveNumberRegex matchesInString:str options:0 range:NSMakeRange(0, string.length)];
+    NSRegularExpression *moveNumberRegex = [NSRegularExpression regularExpressionWithPattern:@"\\s*\\d+\\.{1,3}\\s*" options:0 error:&error];
     int plyCount = 0;
+    NSRange range, nextRange;
+    NSString *str = [attributedString string];
     
-    if([matches count] <= 0){
-        return;
-    }
-    
-    for(int i = 0; i < [matches count]; i++){
-        NSRange range = [matches[i] range];
-        NSRange nextRange = i + 1 == [matches count] ? NSMakeRange(str.length, 0) : [matches[i+1] range];
+    range = [moveNumberRegex rangeOfFirstMatchInString:str options:0 range:NSMakeRange(0, str.length)];
+
+    while(range.location != NSNotFound){
+        nextRange = [moveNumberRegex rangeOfFirstMatchInString:str options:0 range:NSMakeRange(range.location + range.length, str.length - range.location - range.length)];
+        if(nextRange.location == NSNotFound){
+            nextRange = NSMakeRange(attributedString.length - 1, 0);
+        }
+        
         unsigned long start = range.location + range.length;
         unsigned long len = nextRange.location - start;
-        start++; len-=2;
         
-        NSRange firstMove, secondMove;
+        NSRange firstMove, secondMove, remaining;
         [self splitStringMoves:str inRange:NSMakeRange(start, len) firstMove:&firstMove secondMove:&secondMove];
-        [self addMoveAnnotationAndLink:string node:[nodes objectAtIndex:plyCount++] range:firstMove];
+        [self addMoveAnnotationAndLink:attributedString node:[nodes objectAtIndex:plyCount++] range:firstMove];
         
         if(secondMove.location != NSNotFound){
-            [self addMoveAnnotationAndLink:string node:[nodes objectAtIndex:plyCount++] range:secondMove];
+            secondMove.location += [[[nodes objectAtIndex:plyCount - 1] annotation] length];
+            [self addMoveAnnotationAndLink:attributedString node:[nodes objectAtIndex:plyCount++] range:secondMove];
+            remaining = NSMakeRange(secondMove.location + secondMove.length, attributedString.length - (secondMove.location + secondMove.length));
         }
+        else {
+            if(nextRange.length == 0){
+                break;
+            }
+            else{
+                // We can have strings like 2... g5 3. Qd2 where the absence of a second move does not indicate that we are done
+                remaining = NSMakeRange(firstMove.location + firstMove.length, attributedString.length - (firstMove.location + firstMove.length));
+            }
+        }
+        
+        str = [attributedString string];
+        range = [moveNumberRegex rangeOfFirstMatchInString:str options:0 range:remaining];
     }
 }
 

--- a/Stockfish/SFMPosition.mm
+++ b/Stockfish/SFMPosition.mm
@@ -40,8 +40,8 @@ NSString* const moveRegex =
 "[a-h]x[a-h][2-7]|" // Pawn captures (exd5)
 "[a-h][18]=[BRQN]|" // Promotions (c8=Q)
 "[a-h]x[a-h][18]=[BRQN]|" // Capture and promotion (bxa8=Q)
-"O-O|" // Short castle
 "O-O-O|" // Long castle
+"O-O|" // Short castle
 ")"
 "[\\+#]?" // Check / mate
 "([!?]{0,2})" // Move annotation (!?, ??, ?)

--- a/Stockfish/SFMPreferencesWindowController.m
+++ b/Stockfish/SFMPreferencesWindowController.m
@@ -56,7 +56,10 @@
         self.skillCell.enabled = NO;
         self.chooseButton.enabled = NO;
         self.recommendedSettingsButton.enabled = NO;
-        NSAlert *alert = [NSAlert alertWithMessageText:@"Cannot change preferences" defaultButton:@"OK" alternateButton:nil otherButton:nil informativeTextWithFormat:@"Preferences cannot be changed while the engine is analyzing. Stop infinite analysis and try again."];
+        NSAlert *alert = [[NSAlert alloc] init];
+        [alert setMessageText:@"Cannot change preferences"];
+        [alert addButtonWithTitle:@"OK"];
+        [alert setInformativeText:@"Preferences cannot be changed while the engine is analyzing. Stop infinite analysis and try again."];
         [alert beginSheetModalForWindow:self.window completionHandler:nil];
     }
     
@@ -85,11 +88,19 @@
             NSData *bookmarkData = [url bookmarkDataWithOptions:NSURLBookmarkCreationWithSecurityScope includingResourceValuesForKeys:nil relativeToURL:nil error:&error];
             if (error) {
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    [[NSAlert alertWithMessageText:@"Uh-oh" defaultButton:@"OK" alternateButton:nil otherButton:nil informativeTextWithFormat:@"%@", [error description]] beginSheetModalForWindow:self.window completionHandler:nil];
+                    NSAlert *alert = [[NSAlert alloc] init];
+                    [alert setMessageText:@"Uh-oh"];
+                    [alert addButtonWithTitle:@"OK"];
+                    [alert setInformativeText:[error description]];
+                    [alert beginSheetModalForWindow:self.window completionHandler:nil];
                 });
             } else {
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    [[NSAlert alertWithMessageText:@"Saved!" defaultButton:@"OK" alternateButton:nil otherButton:nil informativeTextWithFormat:@"Selected path to Syzygy tablebases was saved."] beginSheetModalForWindow:self.window completionHandler:nil];
+                    NSAlert *alert = [[NSAlert alloc] init];
+                    [alert setMessageText:@"Saved"];
+                    [alert addButtonWithTitle:@"OK"];
+                    [alert setInformativeText:@"Selected path to Syzygy tablebases was saved."];
+                    [alert beginSheetModalForWindow:self.window completionHandler:nil];
                 });
                 [SFMUserDefaults setSandboxBookmarkData:bookmarkData];
                 [[NSNotificationCenter defaultCenter] postNotificationName:SETTINGS_HAVE_CHANGED_NOTIFICATION object:nil];

--- a/Stockfish/SFMUCIEngine.m
+++ b/Stockfish/SFMUCIEngine.m
@@ -139,9 +139,18 @@ static volatile int32_t instancesAnalyzing = 0;
     if ([tokens containsObject:@"currmove"]) {
         // Current move update
         NSString *moveUci = [tokens sfm_objectAfterObject:@"currmove"];
+        if (moveUci == nil) {
+            return;
+        }
         SFMMove *move = [[self.gameToAnalyze.position movesArrayForUci:@[moveUci]] firstObject];
+        if (move == nil) {
+            return;
+        }
         NSString *moveNumber = [tokens sfm_objectAfterObject:@"currmovenumber"];
         NSString *depth = [tokens sfm_objectAfterObject:@"depth"];
+        if (moveNumber == nil || depth == nil) {
+            return;
+        }
         
         [self.delegate uciEngine:self
             didGetNewCurrentMove:move

--- a/Stockfish/SFMWindowController.m
+++ b/Stockfish/SFMWindowController.m
@@ -49,7 +49,10 @@
 {
     // Don't want to deal with multi-game PGN
     if ([self.pgnFile.games count] > 1) {
-        NSAlert *alert = [NSAlert alertWithMessageText:@"Could not paste FEN" defaultButton:@"OK" alternateButton:nil otherButton:nil informativeTextWithFormat:@"Please create a new game first."];
+        NSAlert *alert = [[NSAlert alloc] init];
+        [alert setMessageText:@"Could not paste FEN"];
+        [alert addButtonWithTitle:@"OK"];
+        [alert setInformativeText:@"Please create a new game first."];
         [alert beginSheetModalForWindow:self.window completionHandler:nil];
         return;
     }
@@ -60,7 +63,10 @@
 
     // Validate the FEN string and throw a modal if invalid
     if (![SFMPosition isValidFen:fen]) {
-        NSAlert *alert = [NSAlert alertWithMessageText:@"Could not paste FEN" defaultButton:@"OK" alternateButton:nil otherButton:nil informativeTextWithFormat:@"The FEN string is not valid. Edit your FEN string and try again."];
+        NSAlert *alert = [[NSAlert alloc] init];
+        [alert setMessageText:@"Could not paste FEN"];
+        [alert addButtonWithTitle:@"OK"];
+        [alert setInformativeText:@"The FEN string is not valid. Edit your FEN string and try again."];
         [alert beginSheetModalForWindow:self.window completionHandler:nil];
         return;
     }
@@ -140,14 +146,21 @@
     if ([self.currentGame.position isMate]) {
         BOOL isWhite = [self.currentGame.position sideToMove] == WHITE;
         NSString *resultText = isWhite ? @"0-1" : @"1-0";
-        NSAlert *alert = [NSAlert alertWithMessageText:@"Game over!" defaultButton:@"OK" alternateButton:nil otherButton:nil informativeTextWithFormat: isWhite ? @"Black wins." : @"White wins."];
-        [alert beginSheetModalForWindow:self.window modalDelegate:nil didEndSelector:nil contextInfo:nil];
+        NSAlert *alert = [[NSAlert alloc] init];
+        [alert setMessageText:@"Game over!"];
+        [alert addButtonWithTitle:@"OK"];
+        [alert setInformativeText:isWhite ? @"Black wins." : @"White wins."];
+        [alert beginSheetModalForWindow:self.window completionHandler:nil];
         [self.currentGame setResult:resultText];
     } else if ([self.currentGame.position isImmediateDraw]) {
-        NSAlert *alert = [NSAlert alertWithMessageText:@"Game over!" defaultButton:@"OK" alternateButton:nil otherButton:nil informativeTextWithFormat:@"It's a draw."];
-        [alert beginSheetModalForWindow:self.window modalDelegate:nil didEndSelector:nil contextInfo:nil];
+        NSAlert *alert = [[NSAlert alloc] init];
+        [alert setMessageText:@"Game over!"];
+        [alert addButtonWithTitle:@"OK"];
+        [alert setInformativeText:@"It's a draw."];
+        [alert beginSheetModalForWindow:self.window completionHandler:nil];
         [self.currentGame setResult:@"1/2-1/2"];
     }
+    
 }
 
 - (void)updateNotationView
@@ -217,7 +230,10 @@
     [self.currentGame parseMoveText:&error];
     if (error) {
         [self close];
-        NSAlert *alert = [NSAlert alertWithMessageText:@"Could not open game" defaultButton:@"OK" alternateButton:nil otherButton:nil informativeTextWithFormat:@"Stockfish could not parse the move text. Edit your PGN file and try again."];
+        NSAlert *alert = [[NSAlert alloc] init];
+        [alert setMessageText:@"Could not open game"];
+        [alert addButtonWithTitle:@"OK"];
+        [alert setInformativeText:@"Stockfish could not parse the move text. Edit your PGN file and try again."];
         [alert runModal];
     }
     
@@ -392,17 +408,22 @@
 }
 
 - (void)doMoveWithOverwritePrompt:(SFMMove *)move {
-    NSAlert *alert = [NSAlert alertWithMessageText:@"Overwrite game history?" defaultButton:@"Create variation" alternateButton:@"Cancel" otherButton:@"Overwrite" informativeTextWithFormat:@"You are not at the end of the game. Do you want to create a variation or overwrite the current move ?"];
+    NSAlert *alert = [[NSAlert alloc] init];
+    [alert setMessageText:@"Overwrite game history?"];
+    [alert addButtonWithTitle:@"Create variation"];
+    [alert addButtonWithTitle:@"Cancel"];
+    [alert addButtonWithTitle:@"Overwrite"];
+    [alert setInformativeText:@"You are not at the end of the game. Do you want to create a variation or overwrite the current move ?"];
     [alert beginSheetModalForWindow:self.window completionHandler:^(NSModalResponse returnCode) {
         switch (returnCode) {
-            case 1:
+            case NSAlertFirstButtonReturn:
                 // Create variation
                 [self doMoveForced:move];
                 break;
-            case 0:
+            case NSAlertSecondButtonReturn:
                 // Cancel
                 break;
-            case -1:
+            case NSAlertThirdButtonReturn:
                 // Overwrite
                 [self.currentGame removeSubtreeFromNode:self.currentGame.currentNode.next];
                 [self doMoveForced:move];


### PR DESCRIPTION
The move regex was hacky and was missing support for promotions, now replaced with a proper one. 

An issue with move annotations offsetting the originally calculated ranges was fixed. 

Fixed some XCode warnings, mainly deprecations of `[NSAlert alertWithMessageText]`.