### PR TITLE
Add "File > New from Clipboard" command.

### DIFF
--- a/Stockfish/Base.lproj/MainMenu.xib
+++ b/Stockfish/Base.lproj/MainMenu.xib
@@ -72,6 +72,11 @@
                                     <action selector="newDocument:" target="-1" id="4Si-XN-c54"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="New from Clipboard" keyEquivalent="N" id="CSv-Iz-7yG">
+                                <connections>
+                                    <action selector="newFromClipboard:" target="-2" id="WUq-Me-PLc"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Open…" keyEquivalent="o" id="IAo-SY-fd9">
                                 <connections>
                                     <action selector="openDocument:" target="-1" id="bVn-NM-KNZ"/>

--- a/Stockfish/Constants.h
+++ b/Stockfish/Constants.h
@@ -18,6 +18,7 @@
 
 #define GAME_ERROR_DOMAIN @"SFMGameErrorDomain"
 #define NOT_AT_END_CODE 0
+#define GAME_PARSE_ERROR_CODE 1
 
 // For the board view
 #define EXTERIOR_BOARD_MARGIN 40

--- a/Stockfish/SFMApplication.m
+++ b/Stockfish/SFMApplication.m
@@ -7,6 +7,8 @@
 //
 
 #import "SFMApplication.h"
+#import "SFMDocument.h"
+#import "SFMPGNFile.h"
 #import "SFMPreferencesWindowController.h"
 
 @interface SFMApplication()
@@ -16,6 +18,30 @@
 @end
 
 @implementation SFMApplication
+
+- (IBAction)newFromClipboard:(id)sender
+{
+    NSDocumentController *dc = NSDocumentController.sharedDocumentController;
+    NSPasteboard *pb = NSPasteboard.generalPasteboard;
+    NSString *str = [pb stringForType:NSPasteboardTypeString];
+    str = [str stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+
+    NSError *err = nil;
+    SFMPGNFile *game = [SFMPGNFile gameFromPgnOrFen:str error:&err];
+    if (game == nil) {
+        NSAlert *alert = [[NSAlert alloc] init];
+        [alert setMessageText:@"Could not understand clipboard"];
+        [alert addButtonWithTitle:@"OK"];
+        [alert setInformativeText:@"The text on the clipboard was not understood.  Check that the clipboard contains a valid PGN or FEN and try again."];
+        [alert runModal];
+        return;
+    }
+
+    SFMDocument *doc = (SFMDocument *)[dc openUntitledDocumentAndDisplay:NO error:&err];
+    doc.pgnFile = game;
+    [doc makeWindowControllers];
+    [doc showWindows];
+}
 
 - (void)showHelp:(id)sender
 {

--- a/Stockfish/SFMApplication.m
+++ b/Stockfish/SFMApplication.m
@@ -37,10 +37,27 @@
         return;
     }
 
-    SFMDocument *doc = (SFMDocument *)[dc openUntitledDocumentAndDisplay:NO error:&err];
+    SFMDocument *doc = [self findBlankDocument];
+    if (doc == nil) {
+        doc = (SFMDocument *)[dc openUntitledDocumentAndDisplay:NO error:&err];
+    }
     doc.pgnFile = game;
-    [doc makeWindowControllers];
-    [doc showWindows];
+    if (doc.windowControllers.count == 0) {
+        [doc makeWindowControllers];
+        [doc showWindows];
+    }
+}
+
+- (SFMDocument * _Nullable)findBlankDocument
+{
+    NSDocumentController *dc = NSDocumentController.sharedDocumentController;
+    NSArray<SFMDocument *> * docs = dc.documents;
+    for (SFMDocument * doc in docs) {
+        if (!doc.isDocumentEdited && doc.isInInitialState) {
+            return doc;
+        }
+    }
+    return nil;
 }
 
 - (void)showHelp:(id)sender

--- a/Stockfish/SFMChessGame.h
+++ b/Stockfish/SFMChessGame.h
@@ -31,6 +31,8 @@
 @property (readonly) SFMNode *currentNode;
 @property (nonatomic) NSUndoManager *undoManager;
 
+@property (nonatomic, readonly) BOOL isInInitialState;
+
 #pragma mark - Init
 
 /*!

--- a/Stockfish/SFMChessGame.h
+++ b/Stockfish/SFMChessGame.h
@@ -53,7 +53,7 @@
  If the game was created using move text, call this before calling any other methods.
  @param error
  */
-- (void)parseMoveText:(NSError * __autoreleasing *)error;
+- (BOOL)parseMoveText:(NSError * __autoreleasing *)error;
 
 #pragma mark - State Modification
 

--- a/Stockfish/SFMChessGame.m
+++ b/Stockfish/SFMChessGame.m
@@ -66,17 +66,21 @@
 
 - (SFMNode *)startNode{
     SFMNode *tmp = _currentNode;
-    while(!tmp.isTopNode){
+    while(tmp != nil && !tmp.isTopNode){
         tmp = tmp.parent;
     }
     return tmp;
 }
 
-- (void)parseMoveText:(NSError *__autoreleasing *)error {
+- (BOOL)parseMoveText:(NSError *__autoreleasing *)error {
     if(!_moveTextParsed){
-        _currentNode = [SFMParser parseMoveText:_moveText position:[self.startPosition copy]];
+        _currentNode = [SFMParser parseMoveText:_moveText position:[self.startPosition copy] error:error];
+        if (_currentNode == nil) {
+            return NO;
+        }
         _moveTextParsed = YES;
     }
+    return YES;
 }
 
 #pragma mark - State Modification

--- a/Stockfish/SFMChessGame.m
+++ b/Stockfish/SFMChessGame.m
@@ -72,6 +72,10 @@
     return tmp;
 }
 
+- (BOOL)isInInitialState {
+    return self.moveText == nil;
+}
+
 - (BOOL)parseMoveText:(NSError *__autoreleasing *)error {
     if(!_moveTextParsed){
         _currentNode = [SFMParser parseMoveText:_moveText position:[self.startPosition copy] error:error];

--- a/Stockfish/SFMDocument.h
+++ b/Stockfish/SFMDocument.h
@@ -8,6 +8,14 @@
 
 #import <Cocoa/Cocoa.h>
 
+@class SFMPGNFile;
+
 @interface SFMDocument : NSDocument
+
+/**
+ * Only call this before creating the document window,
+ * otherwise things are going to get messy.
+ */
+- (void)setPgnFile:(SFMPGNFile * _Nonnull)pgnFile;
 
 @end

--- a/Stockfish/SFMDocument.h
+++ b/Stockfish/SFMDocument.h
@@ -12,9 +12,11 @@
 
 @interface SFMDocument : NSDocument
 
+@property (nonatomic, readonly) BOOL isInInitialState;
+
 /**
- * Only call this before creating the document window,
- * otherwise things are going to get messy.
+ * This will update the document window, if one has been
+ * created already.
  */
 - (void)setPgnFile:(SFMPGNFile * _Nonnull)pgnFile;
 

--- a/Stockfish/SFMDocument.m
+++ b/Stockfish/SFMDocument.m
@@ -7,12 +7,13 @@
 //
 
 #import "SFMDocument.h"
+#import "Constants.h"
 #import "SFMWindowController.h"
 #import "SFMPGNFile.h"
 
 @interface SFMDocument()
 
-@property SFMPGNFile *pgnFile;
+@property (nonatomic) SFMPGNFile *pgnFile;
 
 @end
 
@@ -50,15 +51,25 @@
 
 - (BOOL)readFromURL:(NSURL *)url ofType:(NSString *)typeName error:(NSError *__autoreleasing *)outError
 {
-    BOOL readSuccess = NO;
     NSString *fileContents = [NSString stringWithContentsOfURL:url usedEncoding:nil error:outError];
     
     if (fileContents) {
-        readSuccess = YES;
-        self.pgnFile = [[SFMPGNFile alloc] initWithString:fileContents];
+        self.pgnFile = [[SFMPGNFile alloc] initWithString:fileContents error:outError];
+        if (self.pgnFile) {
+            return YES;
+        }
     }
-    return readSuccess;
+
+    if (outError != NULL && *outError == nil) {
+        *outError = [NSError errorWithDomain:GAME_ERROR_DOMAIN code:GAME_PARSE_ERROR_CODE userInfo:nil];
+    }
+    return NO;
     
+}
+
+- (void)setPgnFile:(SFMPGNFile * _Nonnull)pgnFile
+{
+    _pgnFile = pgnFile;
 }
 
 @end

--- a/Stockfish/SFMDocument.m
+++ b/Stockfish/SFMDocument.m
@@ -70,6 +70,21 @@
 - (void)setPgnFile:(SFMPGNFile * _Nonnull)pgnFile
 {
     _pgnFile = pgnFile;
+
+    for (SFMWindowController * win in self.windowControllers) {
+        win.pgnFile = pgnFile;
+        [win handlePGNFile];
+    }
+}
+
+- (BOOL)isInInitialState
+{
+    for (SFMChessGame * game in self.pgnFile.games) {
+        if (!game.isInInitialState) {
+            return NO;
+        }
+    }
+    return YES;
 }
 
 @end

--- a/Stockfish/SFMPGNFile.h
+++ b/Stockfish/SFMPGNFile.h
@@ -23,7 +23,7 @@
  Create the given PGN.
  @param str
  */
-- (instancetype)initWithString:(NSString *)str;
+- (instancetype)initWithString:(NSString *)str error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 #pragma mark - Export
 
@@ -32,5 +32,7 @@
  @return The PGN file as an NSData blob.
  */
 @property (nonatomic, readonly, copy) NSData *data;
+
++ (SFMPGNFile * _Nullable)gameFromPgnOrFen:(NSString * _Nonnull)str error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 @end

--- a/Stockfish/SFMPGNFile.m
+++ b/Stockfish/SFMPGNFile.m
@@ -21,10 +21,11 @@
     }
     return self;
 }
-- (instancetype)initWithString:(NSString *)str
+- (instancetype)initWithString:(NSString *)str error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
     if (self = [super init]) {
-        _games = [SFMParser parseGamesFromString:str];
+        _games = [SFMParser parseGamesFromString:str error:error];
+        return _games == nil ? nil : self;
     }
     return self;
 }
@@ -38,6 +39,21 @@
         [concatString appendString:[game pgnString]];
     }
     return [concatString dataUsingEncoding:NSUTF8StringEncoding];
+}
+
++ (SFMPGNFile * _Nullable)gameFromPgnOrFen:(NSString * _Nonnull)str error:(NSError * _Nullable __autoreleasing * _Nullable)error
+{
+    // If this is a FEN, paste it as a position into a new game.
+    // Otherwise, treat it as a PGN.
+    if ([SFMPosition isValidFen:str]) {
+        SFMPGNFile *pgnFile = [[SFMPGNFile alloc] init];
+        [pgnFile.games removeAllObjects];
+        [pgnFile.games addObject:[[SFMChessGame alloc] initWithFen:str]];
+        return pgnFile;
+    }
+    else {
+        return [[SFMPGNFile alloc] initWithString:str error:error];
+    }
 }
 
 @end

--- a/Stockfish/SFMParser.h
+++ b/Stockfish/SFMParser.h
@@ -16,7 +16,7 @@
  @param str The full PGN string as read from disk.
  @return A mutable array of SFMChessGame objects.
  */
-+ (NSMutableArray *)parseGamesFromString:(NSString *)str;
++ (NSMutableArray * _Nullable)parseGamesFromString:(NSString * _Nonnull)str error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /*!
  Parses the move text for a chess game from a given position and returns the top node
@@ -24,7 +24,7 @@
  @param position The position
  @return The top node of the tree
  */
-+ (SFMNode*) parseMoveText:(NSString*)moveText position:(SFMPosition*)position;
++ (SFMNode * _Nullable) parseMoveText:(NSString * _Nullable)moveText position:(SFMPosition * _Nonnull)position error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /*!
  @return YES if the character is a lower or upper-case letter.

--- a/Stockfish/SFMPosition.h
+++ b/Stockfish/SFMPosition.h
@@ -37,14 +37,14 @@
  @param move The move.
  @param error
  */
-- (void)doMove:(SFMMove *)move error:(NSError * __autoreleasing *)error;
+- (BOOL)doMove:(SFMMove *)move error:(NSError * __autoreleasing *)error;
 
 /*!
  Perform a sequence of moves on the current position
  @param moves The moves
  @param error
  */
-- (void)doMoves:(NSArray *)moves error:(NSError *__autoreleasing *)error;
+- (BOOL)doMoves:(NSArray *)moves error:(NSError *__autoreleasing *)error;
 
 /*!
  Undoes the number of moves on the current position.

--- a/Stockfish/SFMWindowController.h
+++ b/Stockfish/SFMWindowController.h
@@ -15,4 +15,6 @@
 
 @property SFMPGNFile *pgnFile;
 
+- (void)handlePGNFile;
+
 @end

--- a/Stockfish/SFMWindowController.m
+++ b/Stockfish/SFMWindowController.m
@@ -205,20 +205,23 @@
     self.boardView.delegate = self;
     self.boardView.dataSource = self;
     
+    [self.gameListView setDelegate:self];
+    [self.gameListView setDataSource:self];
+    [self.gameListView setSelectionHighlightStyle:NSTableViewSelectionHighlightStyleSourceList];
+
     self.engine = [[SFMUCIEngine alloc] initStockfish];
     self.engine.delegate = self;
     
+    [self handlePGNFile];
+}
+
+- (void)handlePGNFile
+{
     [self loadGameAtIndex:0];
     
     // Decide whether to show or hide the game sidebar
-    if ([self.pgnFile.games count] > 1) {
-        [self.gameListView setDelegate:self];
-        [self.gameListView setDataSource:self];
-        [self.gameListView setSelectionHighlightStyle:NSTableViewSelectionHighlightStyleSourceList];
-    } else {
-        [self.mainSplitView.subviews[0] removeFromSuperview];
-    }
-    
+    BOOL showSidebar = (self.pgnFile.games.count > 1);
+    self.mainSplitView.subviews[0].hidden = !showSidebar;
 }
 
 - (void)loadGameAtIndex:(int)index

--- a/StockfishTests/SFMParserTest.m
+++ b/StockfishTests/SFMParserTest.m
@@ -24,7 +24,10 @@
 - (void)testParseGamesFromString
 {
     NSString *fakepgn = @"[tag \"whoa\"]\r\n[another \"yay\"]\n\n1. e4\re5 2. Nf3\n\n[tag \"whoa\"]\n\n1. e4\n";
-    NSMutableArray *games = [SFMParser parseGamesFromString:fakepgn];
+    NSError *err = nil;
+    NSMutableArray *games = [SFMParser parseGamesFromString:fakepgn error:&err];
+    XCTAssertNotNil(games);
+    XCTAssertNil(err);
     XCTAssertEqual([games count], 2, @"Wrong count");
     SFMChessGame *first = games[0];
     SFMChessGame *second = games[1];
@@ -36,7 +39,10 @@
 {
     SFMPosition *initialPosition = [[SFMPosition alloc] init];
     NSString *moveText = @"1. e4\ne5 2.\rNf3 Nc6\r\n3. Bb5";
-    SFMNode *parsedNode = [SFMParser parseMoveText:moveText position:initialPosition];
+    NSError *err = nil;
+    SFMNode *parsedNode = [SFMParser parseMoveText:moveText position:initialPosition error:&err];
+    XCTAssertNotNil(parsedNode);
+    XCTAssertNil(err);
     NSArray *moves = @[
                        [[SFMMove alloc] initWithFrom:SQ_E2 to:SQ_E4],
                        [[SFMMove alloc] initWithFrom:SQ_E7 to:SQ_E5],
@@ -54,7 +60,10 @@
     SFMPosition *initialPosition = [[SFMPosition alloc] init];
     NSString *moveText = @"1.e4 (1.c4 c5 {Wow} 2.g3) e5 2.Nf3 Nc6 3. Bb5";
     
-    SFMNode *parsed = [SFMParser parseMoveText:moveText position:initialPosition];
+    NSError *err = nil;
+    SFMNode *parsed = [SFMParser parseMoveText:moveText position:initialPosition error:&err];
+    XCTAssertNotNil(parsed);
+    XCTAssertNil(err);
     NSArray *mainMoves = @[
                        [[SFMMove alloc] initWithFrom:SQ_E2 to:SQ_E4],
                        [[SFMMove alloc] initWithFrom:SQ_E7 to:SQ_E5],


### PR DESCRIPTION
This takes the current clipboard content, and handles it either as a FEN position or a PGN game.

As part of this, lots of PGN parsing code needed to be updated to handle errors, since we can no longer trust that the PGN is valid.

This adds the isInInitialState property to SFMChessGame and SFMDocument, so that we can identify an open, clean document that we can re-use, and refresh the extant SFMWindowController, if any.