### PR TITLE
Fix a crash with New from Clipboard and non-text.

### DIFF
--- a/Stockfish/SFMApplication.m
+++ b/Stockfish/SFMApplication.m
@@ -26,6 +26,15 @@
     NSString *str = [pb stringForType:NSPasteboardTypeString];
     str = [str stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
 
+    if (str == nil) {
+        NSAlert *alert = [[NSAlert alloc] init];
+        [alert setMessageText:@"Could not understand clipboard"];
+        [alert addButtonWithTitle:@"OK"];
+        [alert setInformativeText:@"The clipboard does not contain text.  Copy a valid PGN or FEN and try again."];
+        [alert runModal];
+        return;
+    }
+
     NSError *err = nil;
     SFMPGNFile *game = [SFMPGNFile gameFromPgnOrFen:str error:&err];
     if (game == nil) {


### PR DESCRIPTION
Fix a crash when the user uses the New from Clipboard command and
the clipboard does not contain text.  In this case,
NSPasteboard.stringForType returns nil, and we were crashing inside
Position::is_valid_fen with a null pointer.

Show an NSAlert in this case instead.