### PR TITLE
Add "Show WDL" option 

### DIFF
--- a/Stockfish/Base.lproj/MainMenu.xib
+++ b/Stockfish/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="18122" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="18122"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SFMApplication">
@@ -226,6 +226,12 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="toggleUseNnue:" target="-1" id="CYi-ql-Wru"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Show WDL" id="D73-eM-v6f">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="toggleShowWdl:" target="-1" id="NYc-Hf-ILl"/>
                                 </connections>
                             </menuItem>
                         </items>

--- a/Stockfish/SFMUCIEngine.h
+++ b/Stockfish/SFMUCIEngine.h
@@ -32,7 +32,7 @@
 @property (nonatomic) SFMChessGame *gameToAnalyze;
 @property (nonatomic) NSUInteger multipv;
 @property (nonatomic) BOOL useNnue;
-
+@property (nonatomic) BOOL showWdl;
 @property (readonly, nonatomic) NSDictionary /* <NSNumber, SFMUCILine> */ *lines;
 @property (readonly, nonatomic) NSString *nnueInfo;
 

--- a/Stockfish/SFMUCILine.h
+++ b/Stockfish/SFMUCILine.h
@@ -22,7 +22,9 @@
 @property (nonatomic) NSInteger tbHits;
 @property (nonatomic) long long time; // milliseconds
 @property (nonatomic) NSArray *moves;
-
+@property (nonatomic) NSInteger wdlWin;
+@property (nonatomic) NSInteger wdlDraw;
+@property (nonatomic) NSInteger wdlLoss;
 - (instancetype)initWithTokens:(NSArray *)tokens position:(SFMPosition *)position;
 
 @end

--- a/Stockfish/SFMUCILine.m
+++ b/Stockfish/SFMUCILine.m
@@ -26,17 +26,28 @@
         }
         _scoreIsLowerBound = [tokens containsObject:@"lowerbound"];
         _scoreIsUpperBound = [tokens containsObject:@"upperbound"];
+        
+        NSArray *wdl = [tokens sfm_objectsAfterObject:@"wdl" beforeObject:@"nodes"];
+        if (wdl != nil) {
+            _wdlWin = [[wdl objectAtIndex:0] integerValue];
+            _wdlDraw = [[wdl objectAtIndex:1] integerValue];
+            _wdlLoss = [[wdl objectAtIndex:2] integerValue];
+        }
         _nodes = [tokens sfm_objectAfterObject:@"nodes"];
         _nodesPerSecond = [tokens sfm_objectAfterObject:@"nps"];
         _tbHits = [[tokens sfm_objectAfterObject:@"tbhits"] integerValue];
         _time = [[tokens sfm_objectAfterObject:@"time"] longLongValue];
         _moves = [position movesArrayForUci:[tokens sfm_objectsAfterObject:@"pv"]];
+        
         NSAssert(_depth != 0, @"failed to init uci line");
     }
     return self;
 }
 
 - (NSString *)description {
+    if (_wdlWin != 0 || _wdlDraw != 0 || _wdlLoss != 0) {
+        return [NSString stringWithFormat:@"depth=%ld/%ld score=%ld nodes=%ld win=%ld draw=%ld loss=%ld time=%ld pv=%@", (long)self.depth, (long)self.selectiveDepth, (long)self.score, (long)self.wdlWin, (long)self.wdlDraw, (long)self.wdlLoss,  (long)self.nodes, (long)self.time, [self.moves description] ];
+    }
     return [NSString stringWithFormat:@"depth=%ld/%ld score=%ld nodes=%ld time=%ld pv=%@", (long)self.depth, (long)self.selectiveDepth, (long)self.score, (long)self.nodes, (long)self.time, [self.moves description] ];
 }
 

--- a/Stockfish/SFMUserDefaults.h
+++ b/Stockfish/SFMUserDefaults.h
@@ -26,4 +26,7 @@
 + (BOOL)useNnue;
 + (void)setUseNnue:(BOOL)val;
 
++ (BOOL)showWdl;
++ (void)setShowWDL:(BOOL)val;
+
 @end

--- a/Stockfish/SFMUserDefaults.m
+++ b/Stockfish/SFMUserDefaults.m
@@ -14,7 +14,8 @@
 #define SANDBOX_BOOKMARK_DATA @"sandbox_bookmark_data"
 #define ARROWS_ENABLED @"arrows_enabled"
 #define USE_NNUE @"use_nnue"
-
+#define SHOW_WDL @"show_wdl"
+/// <#Description#>
 @implementation SFMUserDefaults
 
 + (NSInteger)threadsValue {
@@ -74,4 +75,13 @@
     [[NSUserDefaults standardUserDefaults] setBool:val forKey:USE_NNUE];
 }
 
++(BOOL)showWdl {
+    if (![[NSUserDefaults standardUserDefaults] objectForKey:SHOW_WDL]) {
+        [SFMUserDefaults setUseNnue:YES];
+    }
+    return [[NSUserDefaults standardUserDefaults] boolForKey:SHOW_WDL];
+}
++ (void)setShowWDL:(BOOL)val {
+    [[NSUserDefaults standardUserDefaults] setBool:val forKey:SHOW_WDL];
+}
 @end

--- a/Stockfish/SFMWindowController.m
+++ b/Stockfish/SFMWindowController.m
@@ -138,7 +138,11 @@
     [SFMUserDefaults setUseNnue:![SFMUserDefaults useNnue]];
     self.engine.useNnue = [SFMUserDefaults useNnue];
 }
+- (IBAction)toggleShowWdl:(id)sender {
+    [SFMUserDefaults setShowWDL:![SFMUserDefaults showWdl]];
+    self.engine.showWdl = [SFMUserDefaults showWdl];
 
+}
 #pragma mark - Helper methods
 - (void)syncToViewsAndEngine
 {
@@ -224,7 +228,7 @@
     self.engine = [[SFMUCIEngine alloc] initStockfish];
     self.engine.delegate = self;
     self.engine.useNnue = [SFMUserDefaults useNnue];
-    
+    self.engine.showWdl = [SFMUserDefaults showWdl];
     [self handlePGNFile];
 }
 
@@ -304,6 +308,8 @@
         [menuItem setState:[SFMUserDefaults arrowsEnabled] ? NSControlStateValueOn : NSControlStateValueOff];
     } else if ([menuItem action] == @selector(toggleUseNnue:)) {
         [menuItem setState:[SFMUserDefaults useNnue] ? NSControlStateValueOn : NSControlStateValueOff];
+    } else if ([menuItem action] == @selector(toggleShowWdl:)) {
+        [menuItem setState:[SFMUserDefaults showWdl] ? NSControlStateValueOn : NSControlStateValueOff];
     }
     return YES;
 }
@@ -389,12 +395,17 @@
         if (line.tbHits) {
             [statusComponents addObject:[NSString stringWithFormat:@"TB=%lu", line.tbHits]];
         }
-        
+
         // 4. Time
         [statusComponents addObject:[SFMFormatter millisecondsToClock:line.time]];
         
         // 5. Nodes
         [statusComponents addObject:[SFMFormatter nodesAsText:line.nodes]];
+
+        // 6. WDL
+        if (engine.showWdl) {
+            [statusComponents addObject:[NSString stringWithFormat:@"\n   Win=%1.1f%% Draw=%1.1f%% Loss=%1.1f%%", (float)line.wdlWin/10, (float)line.wdlDraw/10, (float)line.wdlLoss/10 ]];
+        }
         
         NSAttributedString *secondLine = [[NSAttributedString alloc] initWithString:[statusComponents componentsJoinedByString:@"    "] attributes:@{NSFontAttributeName: [NSFont systemFontOfSize:[NSFont systemFontSize]], NSForegroundColorAttributeName: [NSColor labelColor]}];
         


### PR DESCRIPTION
Stockfish NNUE has added a UCI option "UCI_ShowWDL"  -- see stockfish official readme: "If enabled, show approximate WDL statistics as part of the engine output. These WDL numbers model expected game outcomes for a given evaluation and game ply for engine self-play at fishtest LTC conditions (60+0.6s per game)."

This PR adds a menu option under (Use NNUE) and when enabled sends the UCI command and displays the data in the line details.