### PR TITLE
Variation arrows weight

### DIFF
--- a/Stockfish.xcodeproj/project.pbxproj
+++ b/Stockfish.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2763275B26DB5DC40014A2D4 /* SFMArrowMove.m in Sources */ = {isa = PBXBuildFile; fileRef = 2763275A26DB5DC40014A2D4 /* SFMArrowMove.m */; };
 		77050672187CE43300BA4635 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77050671187CE43300BA4635 /* Cocoa.framework */; };
 		7705067C187CE43300BA4635 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 7705067A187CE43300BA4635 /* InfoPlist.strings */; };
 		7705067E187CE43300BA4635 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 7705067D187CE43300BA4635 /* main.m */; };
@@ -98,6 +99,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2763275926DB5DC40014A2D4 /* SFMArrowMove.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SFMArrowMove.h; path = Stockfish/SFMArrowMove.h; sourceTree = "<group>"; };
+		2763275A26DB5DC40014A2D4 /* SFMArrowMove.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFMArrowMove.m; path = Stockfish/SFMArrowMove.m; sourceTree = "<group>"; };
 		7705066E187CE43300BA4635 /* Stockfish.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Stockfish.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		77050671187CE43300BA4635 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		77050674187CE43300BA4635 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
@@ -408,26 +411,28 @@
 		7715B8AD187E8981006F2366 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				BB5FC6041F6D510500CDD57A /* SFMNode.h */,
-				BB5FC6051F6D510500CDD57A /* SFMNode.m */,
+				2763275926DB5DC40014A2D4 /* SFMArrowMove.h */,
+				2763275A26DB5DC40014A2D4 /* SFMArrowMove.m */,
+				77924AEB187DED010019C56E /* SFMChessGame.h */,
+				77924AEC187DED010019C56E /* SFMChessGame.m */,
 				77CA8B031889C42F004402D2 /* SFMFormatter.h */,
 				77CA8B041889C42F004402D2 /* SFMFormatter.m */,
 				77764F0E1888D2C200A7C4CC /* SFMHardwareDetector.h */,
 				77764F0F1888D2C200A7C4CC /* SFMHardwareDetector.m */,
-				7748D07E18868CD3009E021E /* SFMUCIEngine.h */,
-				7748D07F18868CD3009E021E /* SFMUCIEngine.m */,
-				7745E4FB1A4F7C8A00E5ED35 /* SFMUCIOption.h */,
-				7745E4FC1A4F7C8A00E5ED35 /* SFMUCIOption.m */,
-				7795E2EC1A4CF72C00736550 /* SFMUCILine.h */,
-				7795E2ED1A4CF72C00736550 /* SFMUCILine.m */,
 				7744CCB31A4A2043009D349D /* SFMMove.h */,
 				7744CCB41A4A2043009D349D /* SFMMove.m */,
+				BB5FC6041F6D510500CDD57A /* SFMNode.h */,
+				BB5FC6051F6D510500CDD57A /* SFMNode.m */,
 				77924AFB187E72940019C56E /* SFMParser.h */,
 				77924AFC187E72940019C56E /* SFMParser.m */,
 				77924AE8187DECEB0019C56E /* SFMPGNFile.h */,
 				77924AE9187DECEB0019C56E /* SFMPGNFile.m */,
-				77924AEB187DED010019C56E /* SFMChessGame.h */,
-				77924AEC187DED010019C56E /* SFMChessGame.m */,
+				7748D07E18868CD3009E021E /* SFMUCIEngine.h */,
+				7748D07F18868CD3009E021E /* SFMUCIEngine.m */,
+				7795E2EC1A4CF72C00736550 /* SFMUCILine.h */,
+				7795E2ED1A4CF72C00736550 /* SFMUCILine.m */,
+				7745E4FB1A4F7C8A00E5ED35 /* SFMUCIOption.h */,
+				7745E4FC1A4F7C8A00E5ED35 /* SFMUCIOption.m */,
 				7745E5041A4FA25900E5ED35 /* SFMUserDefaults.h */,
 				7745E5051A4FA25900E5ED35 /* SFMUserDefaults.m */,
 			);
@@ -699,6 +704,7 @@
 				7744CCA61A49EA54009D349D /* misc.cpp in Sources */,
 				7744CCB11A49EF45009D349D /* SFMPosition.mm in Sources */,
 				7734B674189506F500FC4D79 /* SFMArrowView.m in Sources */,
+				2763275B26DB5DC40014A2D4 /* SFMArrowMove.m in Sources */,
 				77924AFD187E72940019C56E /* SFMParser.m in Sources */,
 				77CA8B051889C42F004402D2 /* SFMFormatter.m in Sources */,
 				7795E2EE1A4CF72C00736550 /* SFMUCILine.m in Sources */,

--- a/Stockfish/SFMArrowMove.h
+++ b/Stockfish/SFMArrowMove.h
@@ -1,0 +1,24 @@
+//
+//  SFMArrowMove.h
+//  Stockfish
+//
+//  Created by Peter Ryszkiewicz on 8/28/21.
+//  Copyright © 2021 Daylen Yang. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class SFMMove;
+
+@interface SFMArrowMove : NSObject <NSCopying>
+
+@property (readonly) SFMMove *move;
+@property (readonly, assign) CGFloat weight; // [0, 1]
+
+- (instancetype)initWithMove:(SFMMove *)move weight:(CGFloat)arrowWeight;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Stockfish/SFMArrowMove.h
+++ b/Stockfish/SFMArrowMove.h
@@ -15,7 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SFMArrowMove : NSObject <NSCopying>
 
 @property (readonly) SFMMove *move;
-@property (readonly, assign) CGFloat weight; // [0, 1]
+
+/// Describes relative thickness of arrow in [0, 1]
+@property (readonly, assign) CGFloat weight;
 
 - (instancetype)initWithMove:(SFMMove *)move weight:(CGFloat)arrowWeight;
 

--- a/Stockfish/SFMArrowMove.m
+++ b/Stockfish/SFMArrowMove.m
@@ -1,0 +1,29 @@
+//
+//  SFMArrowMove.m
+//  Stockfish
+//
+//  Created by Peter Ryszkiewicz on 8/28/21.
+//  Copyright © 2021 Daylen Yang. All rights reserved.
+//
+
+#import "SFMArrowMove.h"
+
+@implementation SFMArrowMove
+
+- (instancetype)initWithMove:(SFMMove *)move weight:(CGFloat)weight
+{
+    self = [super init];
+    if (self) {
+        _move = move;
+        _weight = weight;
+    }
+    return self;
+}
+
+- (nonnull id)copyWithZone:(nullable NSZone *)zone {
+    return [[SFMArrowMove alloc]
+            initWithMove:self.move
+            weight:self.weight];
+}
+
+@end

--- a/Stockfish/SFMArrowView.h
+++ b/Stockfish/SFMArrowView.h
@@ -11,5 +11,6 @@
 @property CGPoint fromPoint;
 @property CGPoint toPoint;
 @property CGFloat squareSideLength;
+@property CGFloat weight;
 
 @end

--- a/Stockfish/SFMArrowView.m
+++ b/Stockfish/SFMArrowView.m
@@ -15,7 +15,7 @@
 {
     [[NSColor colorWithSRGBRed:1 green:0 blue:0 alpha:0.5] set];
     
-    CGFloat arrowLineWidth = self.squareSideLength * 0.2;
+    CGFloat arrowLineWidth = self.squareSideLength * 0.2 * self.weight;
     
     NSBezierPath *path = [NSBezierPath bezierPathWithArrowFromPoint:self.fromPoint
                                                             toPoint:self.toPoint

--- a/Stockfish/SFMBoardView.h
+++ b/Stockfish/SFMBoardView.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 Daylen Yang. All rights reserved.
 //
 
+@class SFMArrowMove;
 @class SFMPosition;
 @class SFMBoardView;
 @class SFMMove;
@@ -54,6 +55,6 @@
 /*!
  The arrows to display.
  */
-@property (nonatomic) NSArray /* of SFMMove */ *arrows;
+@property (nonatomic) NSArray<SFMArrowMove *> *arrows;
 
 @end

--- a/Stockfish/SFMBoardView.m
+++ b/Stockfish/SFMBoardView.m
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 Daylen Yang. All rights reserved.
 //
 
+#import "SFMArrowMove.h"
 #import "SFMPosition.h"
 #import "SFMBoardView.h"
 #import "Constants.h"
@@ -31,7 +32,7 @@
 #pragma mark - State
 
 @property (nonatomic) NSMutableDictionary /* <NSNumber(SFMSquare), SFMPieceView> */ *pieceViews;
-@property (nonatomic) NSMutableDictionary /* <SFMMove, SFMArrowView> */ *arrowViews;
+@property (nonatomic) NSMutableDictionary<SFMArrowMove *, SFMArrowView *> *arrowViews;
 
 @property (nonatomic) NSArray /* of NSNumber(SFMSquare) */ *highlightedSquares;
 
@@ -92,15 +93,16 @@
     }];
     [self.arrowViews removeAllObjects];
     
-    for (SFMMove *move in _arrows) {
-        if (move.from == move.to) {
+    for (SFMArrowMove *arrowMove in _arrows) {
+        if (arrowMove.move.from == arrowMove.move.to) {
             NSLog(@"Yikes! The from and to for this arrow is the same.");
             continue;
         }
         
-        SFMArrowView *view = [[SFMArrowView alloc] initWithFrame:self.bounds];
-        self.arrowViews[move] = view;
-        [self addSubview:view];
+        SFMArrowView *arrowView = [[SFMArrowView alloc] initWithFrame:self.bounds];
+        arrowView.weight = arrowMove.weight;
+        self.arrowViews[arrowMove] = arrowView;
+        [self addSubview:arrowView];
     }
     
     [self resizeSubviewsWithOldSize:NSMakeSize(0, 0)];
@@ -121,19 +123,17 @@
                                     self.squareSideLength, self.squareSideLength);
         }];
     }
-    [self.arrowViews enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
-        SFMMove *move = key;
-        SFMArrowView *view = obj;
-        view.fromPoint = [self coordinatesForSquare:move.from
+    [self.arrowViews enumerateKeysAndObjectsUsingBlock:^(SFMArrowMove *arrowMove, SFMArrowView *arrowView, BOOL *stop) {
+        arrowView.fromPoint = [self coordinatesForSquare:arrowMove.move.from
                                          leftOffset:self.leftInset + self.squareSideLength / 2
                                           topOffset:self.topInset + self.squareSideLength / 2
                                          sideLength:self.squareSideLength];
-        view.toPoint = [self coordinatesForSquare:move.to
+        arrowView.toPoint = [self coordinatesForSquare:arrowMove.move.to
                                        leftOffset:self.leftInset + self.squareSideLength / 2
                                         topOffset:self.topInset + self.squareSideLength / 2
                                        sideLength:self.squareSideLength];
-        view.squareSideLength = self.squareSideLength;
-        [view setNeedsDisplay:YES];
+        arrowView.squareSideLength = self.squareSideLength;
+        [arrowView setNeedsDisplay:YES];
     }];
 }
 

--- a/Stockfish/SFMWindowController.m
+++ b/Stockfish/SFMWindowController.m
@@ -203,6 +203,22 @@
     return YES;
 }
 
+- (void)updateArrowsFromLines:(NSDictionary<NSNumber *, SFMUCILine *> *const)linesDict {
+    if(![SFMUserDefaults arrowsEnabled]) {
+        return;
+    }
+    
+    NSMutableArray<SFMMove *> *const arrows = [NSMutableArray new];
+    
+    for (SFMUCILine *const line in [linesDict allValues]) {
+        if(line.moves.count) {
+            [arrows addObject: [line.moves firstObject]];
+        }
+    }
+    
+    self.boardView.arrows = arrows;
+}
+
 #pragma mark - Init
 - (void)windowDidLoad
 {
@@ -357,12 +373,9 @@
     if (pv) {
         // Update the status text
         [self uciEngine:engine didGetNewCurrentMove:nil number:0 depth:pv.depth];
-        
-        // Draw an arrow
-        if ([pv.moves count] > 0 && [SFMUserDefaults arrowsEnabled]) {
-            self.boardView.arrows = @[[pv.moves firstObject]];
-        }
     }
+    
+    [self updateArrowsFromLines:lines];
     
     NSMutableAttributedString *combined = [[NSMutableAttributedString alloc] init];
     

--- a/Stockfish/SFMWindowController.m
+++ b/Stockfish/SFMWindowController.m
@@ -9,6 +9,7 @@
 #import "SFMWindowController.h"
 #import "SFMChessGame.h"
 #import "Constants.h"
+#import "SFMArrowMove.h"
 #import "SFMFormatter.h"
 #import "SFMMove.h"
 #import "SFMUCILine.h"
@@ -208,15 +209,20 @@
         return;
     }
     
-    NSMutableArray<SFMMove *> *const arrows = [NSMutableArray new];
+    NSMutableArray<SFMArrowMove *> *const arrowMoves = [NSMutableArray new];
+    
+    const CGFloat topVariationScore = linesDict[@(1)].score;
     
     for (SFMUCILine *const line in [linesDict allValues]) {
         if(line.moves.count) {
-            [arrows addObject: [line.moves firstObject]];
+            SFMArrowMove *const arrowMove = [[SFMArrowMove alloc]
+                                             initWithMove:[line.moves firstObject]
+                                             weight:((CGFloat) line.score) / topVariationScore];
+            [arrowMoves addObject: arrowMove];
         }
     }
     
-    self.boardView.arrows = arrows;
+    self.boardView.arrows = arrowMoves;
 }
 
 #pragma mark - Init


### PR DESCRIPTION
This makes it much easer to tell, at a glance, which moves are better, as shown by the width of the arrows. 

I considered hiding this behind a flag in user preferences, like, `enableWeightedArrows`. Let me know if this should be done.

Some examples:

<img width="1072" alt="Screen Shot 2021-08-29 at 12 09 46 AM" src="https://user-images.githubusercontent.com/3519085/131241980-94a8d0a4-8cef-4b7a-886f-53589f2a2a8d.png">

<img width="1072" alt="Screen Shot 2021-08-29 at 12 11 31 AM" src="https://user-images.githubusercontent.com/3519085/131241976-964cbfd9-f79b-4e4e-a525-506f8df35c93.png">

Fixing a few issues with weighting; negative weights; 0 weights
