### PR TITLE
Fix handling of invalid tokens when game is saved while simulating

### DIFF
--- a/Stockfish/SFMChessGame.m
+++ b/Stockfish/SFMChessGame.m
@@ -269,7 +269,11 @@
     
     [str appendString:@"\n"];
     [str appendString:[[self moveTextString] string]];
-    [str appendFormat:@"%@\n\n", self.tags[@"Result"]];
+    if (self.tags[@"Result"] == nil) {
+        [str appendString:@"\n"];
+    } else {
+        [str appendFormat:@"%@\n\n", self.tags[@"Result"]];
+    }
 
     return str;
 }

--- a/Stockfish/SFMChessGame.m
+++ b/Stockfish/SFMChessGame.m
@@ -11,6 +11,8 @@
 #import "SFMParser.h"
 #import "SFMNode.h"
 
+static NSString * const SFMUnknownResult = @"*";
+
 @interface SFMChessGame()
 
 @property (nonatomic, readonly) SFMNode *startNode;
@@ -36,7 +38,7 @@
                   @"Round": @"1",
                   @"White": @"?",
                   @"Black": @"?",
-                  @"Result": @"*"};
+                  @"Result": SFMUnknownResult};
         _currentNode = [[SFMNode alloc] init];
         _position = [[SFMPosition alloc] init];
         _undoManager = [[NSUndoManager alloc] init];
@@ -269,11 +271,8 @@
     
     [str appendString:@"\n"];
     [str appendString:[[self moveTextString] string]];
-    if (self.tags[@"Result"] == nil) {
-        [str appendString:@"\n"];
-    } else {
-        [str appendFormat:@"%@\n\n", self.tags[@"Result"]];
-    }
+    NSString *result = self.tags[@"Result"];
+    [str appendFormat:@"%@\n\n", [result length] > 0 ? result : SFMUnknownResult];
 
     return str;
 }

--- a/Stockfish/SFMParser.m
+++ b/Stockfish/SFMParser.m
@@ -130,6 +130,11 @@
     return currentNode;
 }
 
++ (BOOL)isValidToken:(NSString*)token
+{
+    return token != nil && ![@"(null)" isEqualToString:token];
+}
+
 /*!
  Splits the string into tokens at the same depth. A token can be: move sequence, variation or comment
  */
@@ -173,7 +178,9 @@
         [tokens addObject:[str substringWithRange:NSMakeRange(tokenStartIndex, [str length] - tokenStartIndex)]];
     }
     
-    return tokens;
+    return [tokens objectsAtIndexes:[tokens indexesOfObjectsPassingTest:^BOOL(id token, NSUInteger idx, BOOL * stop) {
+        return [SFMParser isValidToken:token];
+    }]];
 }
 
 + (BOOL)isLetter:(char)c

--- a/Stockfish/SFMParser.m
+++ b/Stockfish/SFMParser.m
@@ -70,13 +70,17 @@
 
 + (SFMNode * _Nullable)parseMoveText:(NSString * _Nullable)moveText position:(SFMPosition * _Nonnull)position error:(NSError * _Nullable __autoreleasing * _Nullable)error {
     SFMNode *head = [[SFMNode alloc] init];
-    if (moveText == nil || [moveText isEqualToString:@""]) {
+    if (moveText == nil) {
         return head;
     }
     NSMutableCharacterSet *charactersToTrim = [[NSMutableCharacterSet alloc] init];
     [charactersToTrim formUnionWithCharacterSet:[NSCharacterSet whitespaceCharacterSet]];
     [charactersToTrim formUnionWithCharacterSet:[NSCharacterSet characterSetWithCharactersInString:@"*"]];
-    return [self parseString:[moveText stringByTrimmingCharactersInSet:charactersToTrim] fromNode:head position:position error:error];
+    NSString *moves = [moveText stringByTrimmingCharactersInSet:charactersToTrim];
+    if ([moves length] == 0) {
+        return head;
+    }
+    return [self parseString:moves fromNode:head position:position error:error];
 }
 
 + (SFMNode * _Nullable)parseString:(NSString * _Nonnull)str fromNode:(SFMNode * _Nonnull)node position:(SFMPosition * _Nonnull)position error:(NSError * _Nullable __autoreleasing * _Nullable)error
@@ -112,6 +116,10 @@
         SFMNode *dummy = [[SFMNode alloc] initWithPly:currentNode.ply - 1];
         SFMNode * parsedNode = [SFMParser parseString:[token substringWithRange:NSMakeRange(1, [token length] - 2)] fromNode:dummy position:[position copy] error:error];
         if (parsedNode == nil) {
+            return nil;
+        }
+        BOOL variationHasNoMoves = dummy.next == nil;
+        if (variationHasNoMoves) {
             return nil;
         }
         [dummy.next setParent:currentNode.parent];

--- a/StockfishTests/SFMChessGameTest.m
+++ b/StockfishTests/SFMChessGameTest.m
@@ -52,6 +52,25 @@
     XCTAssertEqualObjects([[game moveTextString] string], @"1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 ");
 }
 
+- (void)testPgnStringAlwaysWritesGameTerminationMarker
+{
+    NSArray *tagsAndExpectedMarker = @[
+                                       @[@{@"Event": @"A"}, @"*"],
+                                       @[@{@"Event": @"A", @"Result": @""}, @"*"],
+                                       @[@{@"Event": @"A", @"Result": @"1-0"}, @"1-0"],
+                                       ];
+    for (NSArray *testCase in tagsAndExpectedMarker) {
+        NSDictionary *tags = testCase[0];
+        NSString *expectedMarker = testCase[1];
+        SFMChessGame *game = [[SFMChessGame alloc] initWithTags:tags moveText:@"1. e4 e5"];
+        [game parseMoveText:nil];
+        NSString *pgn = [game pgnString];
+        XCTAssertEqual([pgn rangeOfString:@"(null)"].location, (NSUInteger)NSNotFound);
+        XCTAssertTrue([pgn hasSuffix:[expectedMarker stringByAppendingString:@"\n\n"]],
+                      @"Expected termination marker %@ for tags %@, got: %@", expectedMarker, tags, pgn);
+    }
+}
+
 - (void)testUciStringOutput
 {
     SFMChessGame *game = [[SFMChessGame alloc] initWithTags:@{} moveText:@"1. e4 e5"];

--- a/StockfishTests/SFMParserTest.m
+++ b/StockfishTests/SFMParserTest.m
@@ -86,6 +86,54 @@
     [self verifyNodeSubtree:parsed against:expected];
 }
 
+- (void)testExportedGameWithoutResultTagKeepsGameBoundary
+{
+    NSString *pgn = @"[Event \"A\"]\n[White \"First game\"]\n\n1/2-1/2\n\n[Event \"B\"]\n[White \"Second game\"]\n[Result \"*\"]\n\n1. e4 *\n";
+    NSError *error = nil;
+    NSMutableArray *games = [SFMParser parseGamesFromString:pgn error:&error];
+    XCTAssertNil(error);
+    XCTAssertEqual([games count], 2, @"Fixture should load as two games");
+
+    NSMutableString *exported = [NSMutableString new];
+    for (SFMChessGame *game in games) {
+        [exported appendString:[game pgnString]];
+    }
+
+    NSError *reimportError = nil;
+    NSMutableArray *reimported = [SFMParser parseGamesFromString:exported error:&reimportError];
+    XCTAssertNil(reimportError);
+    XCTAssertEqual([reimported count], 2, @"Round trip lost a game");
+    XCTAssertEqualObjects([(SFMChessGame *)reimported[0] tags][@"Event"], @"A");
+    XCTAssertEqualObjects([(SFMChessGame *)reimported[1] tags][@"Event"], @"B");
+}
+
+- (void)testMovelessGameWithTerminationMarkerParses
+{
+    NSString *pgn = @"[Event \"A\"]\n\n*\n\n[Event \"B\"]\n\n1. e4 *\n";
+    NSError *error = nil;
+    NSMutableArray *games = [SFMParser parseGamesFromString:pgn error:&error];
+    XCTAssertNil(error);
+    XCTAssertEqual([games count], 2);
+    XCTAssertEqualObjects([[(SFMChessGame *)games[0] moveTextString] string], @"");
+    XCTAssertEqualObjects([[(SFMChessGame *)games[1] moveTextString] string], @"1. e4 ");
+}
+
+- (void)testVariationWithoutMovesIsRejectedInsteadOfThrowing
+{
+    NSArray *malformedMoveTexts = @[@"1. e4 ( (null) ) *",
+                                    @"1. e4 ({comment}(null)) *",
+                                    @"1. e4 ({no moves here}) *"];
+    for (NSString *moveText in malformedMoveTexts) {
+        NSError *error = nil;
+        __block SFMNode *parsed = nil;
+        XCTAssertNoThrow(parsed = [SFMParser parseMoveText:moveText
+                                                  position:[[SFMPosition alloc] init]
+                                                     error:&error], @"Threw on %@", moveText);
+        XCTAssertNil(parsed, @"Accepted %@", moveText);
+        XCTAssertNotNil(error, @"No error reported for %@", moveText);
+    }
+}
+
 - (SFMNode*)buildNodeFromMoveArray:(NSArray*)moves parent:(SFMNode*)parent
 {
     SFMNode *head = [[SFMNode alloc] initWithMove:[moves firstObject] andParent:parent];


### PR DESCRIPTION
Saving a game whose `Result` tag is missing wrote the literal text `(null)` into the PGN, which then made the file impossible to reopen. Fixes #110.

The exporter now always ends a game with a termination marker, falling back to `*` when the `Result` tag is absent or empty. Writing nothing there is not an option: `parseGamesFromString` starts a new game only when it meets a line that is neither blank nor a tag, so a moveless game with no marker lets the following game's headers overwrite its own and one game disappears from the file with no error at all.

That fallback depends on `parseMoveText` accepting a movetext that consists only of a termination marker. It previously rejected one, so a moveless game could be written but not read back. It now round-trips.

`(null)` tokens are still dropped from the token stream, so files already corrupted on disk can be opened. Dropping one can leave a variation whose body parses to no move, and inserting that nil node into the variations array raised `NSInvalidArgumentException`; because `NSApplicationCrashOnExceptions` is registered, that terminated the app instead of reporting a bad file. A variation that parsed no move is now rejected, which also covers the comment-only and move-number-only variations that crashed before this change.

Left alone: an unterminated `(` or `{` at the end of a movetext, and a bracketed line carrying no quotes, both still raise an uncaught exception when a file is opened. Neither involves `(null)` and both predate this branch.
