### PR TITLE
Build and test on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Build and test
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+
+      - name: Select Xcode
+        run: sudo xcode-select --switch /Applications/Xcode_26.6.app
+
+      - name: Build and test
+        run: |
+          xcodebuild test \
+            -project Stockfish.xcodeproj \
+            -scheme Stockfish \
+            -configuration Debug \
+            -destination 'platform=macOS' \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY=""

--- a/Stockfish.xcodeproj/xcshareddata/xcschemes/Stockfish.xcscheme
+++ b/Stockfish.xcodeproj/xcshareddata/xcschemes/Stockfish.xcscheme
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1610"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7705066D187CE43300BA4635"
+               BuildableName = "Stockfish.app"
+               BlueprintName = "Stockfish"
+               ReferencedContainer = "container:Stockfish.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "77050691187CE43400BA4635"
+               BuildableName = "StockfishTests.xctest"
+               BlueprintName = "StockfishTests"
+               ReferencedContainer = "container:Stockfish.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "77050691187CE43400BA4635"
+               BuildableName = "StockfishTests.xctest"
+               BlueprintName = "StockfishTests"
+               ReferencedContainer = "container:Stockfish.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7705066D187CE43300BA4635"
+            BuildableName = "Stockfish.app"
+            BlueprintName = "Stockfish"
+            ReferencedContainer = "container:Stockfish.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7705066D187CE43300BA4635"
+            BuildableName = "Stockfish.app"
+            BlueprintName = "Stockfish"
+            ReferencedContainer = "container:Stockfish.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Runs `xcodebuild test` on every pull request and every push to master. The project has 24 tests that nothing has been running.

The build disables code signing, so the workflow needs no certificate, no provisioning profile and no secrets, and runs unchanged on a pull request from a fork. The token is scoped to `contents: read`.

The scheme is checked in because until now there was none: the only `Stockfish` scheme lived in `xcuserdata`, and a fresh clone builds solely because Xcode autocreates a scheme when it finds none. A workflow that names `-scheme Stockfish` should name something the repository actually contains.

Tests run under `Debug` rather than the project's own `Test` configuration. `Test` omits `ENABLE_TESTABILITY`, which `Debug` sets; both pass the suite today, but a configuration that leaves testability off is the wrong one to pin CI to. Its other distinction, blanking `CODE_SIGN_IDENTITY`, is what the command-line signing flags now do.

The runner image and Xcode are pinned to macos-26 and Xcode 26.6, the toolchain the suite was verified against locally, so a toolchain change is a deliberate edit rather than a silent reroll. The cost is that when `macos-26` is retired an untouched repository goes red until someone bumps one line.
